### PR TITLE
fix(effects): Make sure techs like Chieftains apply

### DIFF
--- a/src/sim/TechLogic.ts
+++ b/src/sim/TechLogic.ts
@@ -151,7 +151,8 @@ export function shouldApplyEffect(
     const { cls: encodedCls } = decodeEncoded(val);
     const hasArmorClass = u.armors && String(encodedCls) in u.armors;
     const matchesBaseClass = encodedCls === u.class;
-    if (!hasArmorClass && !matchesBaseClass) return false;
+    const hasBonusClass = u.bonuses && String(encodedCls) in u.bonuses;
+    if (!hasArmorClass && !matchesBaseClass && !hasBonusClass) return false;
 
     if (attribute === EFFECT_ATTRIBUTES.attack) {
       if (encodedCls === 3 && (u.patk || 0) === 0) return false;

--- a/tests/ChieftainsPikeman.test.ts
+++ b/tests/ChieftainsPikeman.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { shouldApplyEffect, decodeEncoded } from '../src/sim/TechLogic';
+import { units } from '../src/data/units';
+import { techs } from '../src/data/techs';
+
+describe('Chieftains +5 bonus vs Cavalry for Pikemen', () => {
+  const pikeman = units['pikeman'];
+  const chieftains = techs['chieftains'];
+
+  it('should apply Chieftains +5 attack vs cavalry to Pikeman', () => {
+    const cavAttackEffect = chieftains.effects.find((e) => e.attribute === 9 && e.class === 6 && e.unitId === -1);
+    expect(cavAttackEffect).toBeDefined();
+    const { cls, amt } = decodeEncoded(cavAttackEffect!.value);
+    expect(cls).toBe(8); // Cavalry
+    expect(amt).toBe(5);
+
+    const applied = shouldApplyEffect(cavAttackEffect!, pikeman, chieftains.effects, 3);
+    expect(applied).toBe(true);
+  });
+
+  it('should apply Chieftains +4 attack vs camel to Pikeman', () => {
+    const camelAttackEffect = chieftains.effects.find(
+      (e) => e.attribute === 9 && e.class === 6 && e.unitId === -1 && e !== chieftains.effects[0],
+    );
+    expect(camelAttackEffect).toBeDefined();
+    const { cls, amt } = decodeEncoded(camelAttackEffect!.value);
+    expect(cls).toBe(30); // Camel
+    expect(amt).toBe(4);
+
+    const applied = shouldApplyEffect(camelAttackEffect!, pikeman, chieftains.effects, 3);
+    expect(applied).toBe(true);
+  });
+});


### PR DESCRIPTION
Unique techs weren't correctly applying extra bonus damage. So +5 against cavalry was not working for Vikings pikeman with chieftains.